### PR TITLE
Changed paths to host data and tools

### DIFF
--- a/notebooks/drive_anon_example.ipynb
+++ b/notebooks/drive_anon_example.ipynb
@@ -75,20 +75,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # make a directory for custom repos outside the topohack git repo. (better not to nest git repositories)\n",
-    "# ! mkdir ../../repos\n",
+    "# change your working directory to the third-party-tools directory\n",
+    "%cd ../../third-party-tools\n",
     "\n",
-    "# # change your working directory to the new repos directory\n",
-    "# %cd ../../repos\n",
-    "\n",
-    "# # git clone driveanon (not available via pip or conda at this time)\n",
-    "# ! git clone https://github.com/tjcrone/driveanon.git\n",
+    "# git clone driveanon (not available via pip or conda at this time)\n",
+    "! git clone https://github.com/tjcrone/driveanon.git\n",
     "    \n",
-    "# # install the repo\n",
-    "# ! pip install ./driveanon\n",
+    "# install the tool\n",
+    "! pip install ./driveanon\n",
     "\n",
-    "# # change your working directory back to where you were\n",
-    "# %cd ../topohack/notebooks"
+    "# change your working directory back to where you were\n",
+    "%cd ../topohack/notebooks"
    ]
   },
   {
@@ -118,33 +115,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "! mkdir ../data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Errno 2] No such file or directory: '../data'\n",
-      "/Users/knuth/Desktop/ice_sat_hack/topohack/notebooks\n",
-      "/Users/knuth/Desktop/ice_sat_hack/topohack/notebooks\n"
-     ]
-    }
-   ],
-   "source": [
     "# this might take a little bit to download the 6 GB of data\n",
-    "%cd ../data\n",
+    "%cd ../../data\n",
     "da.save(blob_id)\n",
-    "%cd ../notebooks"
+    "%cd ../topohack/notebooks"
    ]
   },
   {
@@ -153,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! unzip ../data/wa_lidar_baker.zip -d ../data/"
+    "! unzip ../../data/wa_lidar_baker.zip -d ../../data/"
    ]
   },
   {
@@ -169,15 +147,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! rm ../data/wa_lidar_baker.zip"
+    "! rm ../../data/wa_lidar_baker.zip"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ice] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ice-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -189,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/drive_anon_example.ipynb
+++ b/notebooks/drive_anon_example.ipynb
@@ -75,17 +75,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# change your working directory to the third-party-tools directory\n",
-    "%cd ../../third-party-tools\n",
+    "# # change your working directory to the third-party-tools directory\n",
+    "# %cd ~/third-party-tools\n",
     "\n",
-    "# git clone driveanon (not available via pip or conda at this time)\n",
-    "! git clone https://github.com/tjcrone/driveanon.git\n",
+    "# # git clone driveanon (not available via pip or conda at this time)\n",
+    "# ! git clone https://github.com/tjcrone/driveanon.git\n",
     "    \n",
-    "# install the tool\n",
-    "! pip install ./driveanon\n",
+    "# # install the tool\n",
+    "# ! pip install ./driveanon\n",
     "\n",
-    "# change your working directory back to where you were\n",
-    "%cd ../topohack/notebooks"
+    "# # change your working directory back to where you were\n",
+    "# %cd ~/topohack/notebooks"
    ]
   },
   {
@@ -115,23 +115,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "# this might take a little bit to download the 6 GB of data\n",
-    "%cd ../../data\n",
+    "%cd ~/data\n",
     "da.save(blob_id)\n",
-    "%cd ../topohack/notebooks"
+    "%cd ~/topohack/notebooks"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "! unzip ../../data/wa_lidar_baker.zip -d ../../data/"
+    "! unzip ~/data/wa_lidar_baker.zip -d ~/data/"
    ]
   },
   {
@@ -143,11 +143,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "! rm ../../data/wa_lidar_baker.zip"
+    "! rm ~/data/wa_lidar_baker.zip"
    ]
   }
  ],

--- a/scripts/create_bash_profile.sh
+++ b/scripts/create_bash_profile.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+
+# run $source ~/.bash_profile after running this script
+
+
+FILE=~/.bash_profile
+
+if [ -f "$FILE" ]; then
+    echo "$FILE already exists."
+else 
+    touch ~/.bash_profile
+    
+    # add convenience functions
+    echo "alias ll='ls -FGlAhp'" >> ~/.bash_profile
+    echo "alias which='type -all'" >> ~/.bash_profile
+    
+    # add Ames Stereo Pipeline to path
+    echo 'export PATH="~/third-party-tools/asp/StereoPipeline/bin:$PATH"' >> ~/.bash_profile
+    
+fi

--- a/scripts/get_asp_daily.sh
+++ b/scripts/get_asp_daily.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+# make directory for software/asp
+dir=~/third-party-tools/asp/
+if [ ! -d $dir ] ; then
+  mkdir -pv $dir
+fi
+cd $dir
+
+# grab latest tarball
+wget -r -l1 --no-check-certificate --no-directories --no-parent -Ax86_64-Linux.tar.bz2 http://byss.arc.nasa.gov/stereopipeline/daily_build/
+
+# get tarball name, extract and remove
+tarball=$(ls -t *x86_64-Linux.tar.bz2 | head -1 )
+tar -jvxf $tarball
+rm $tarball
+
+# backup previously downloaded version
+if [ -d $dir/StereoPipeline ] ; then
+  rm -rf $dir/StereoPipeline_previous
+  mv $dir/StereoPipeline $dir/StereoPipeline_previous
+fi
+
+# rename current version to match executable path in .bash_profile or .bashrc. E.g. export PATH="$HOME/sw/asp/StereoPipeline/bin:$PATH"
+mv $dir/StereoPipeline*Linux $dir/StereoPipeline
+


### PR DESCRIPTION
Now points to third-party-tools folder to host driveanon package. Other software and tools we use can be hosted here as well.

Puts data in data folder at $HOME instead of inside topohack repo.